### PR TITLE
Use "C" locale for system ping command on Linux

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 * `is_online()` now tries the Apple captive test first, because it works better
   when DNS is not masked, but HTTP is (#13).
 
+* `ping()` now works on Linux systems with a non-English locale
+  [@pekkarr](https://github.com/pekkarr) (#18).
+
 # 2.0.0
 
 * New `nsl()` function to perform DNS queries.

--- a/R/ping-package.r
+++ b/R/ping-package.r
@@ -67,7 +67,7 @@ ping <- function(destination, continuous = FALSE, verbose = continuous,
 
   os <- ping_os(destination, continuous, count, timeout)
 
-  status <- run(os$cmd[1], os$cmd[-1], error_on_status = FALSE)
+  status <- run(os$cmd[1], os$cmd[-1], error_on_status = FALSE, env = os$env)
   output <- strsplit(status$stdout, "\r?\n")[[1]]
 
   if (!continuous) {
@@ -82,6 +82,8 @@ ping <- function(destination, continuous = FALSE, verbose = continuous,
 }
 
 ping_os <- function(destination, continuous, count, timeout) {
+
+  env <- NULL
 
   if (.Platform$OS.type == "windows") {
     ping_file <- file.path("C:", "windows", "system32", "ping.exe")
@@ -108,6 +110,7 @@ ping_os <- function(destination, continuous, count, timeout) {
       if (!continuous) c("-c", count),
       destination
     )
+    env <- c("current", LC_ALL = "C")
 
   } else if (Sys.info()[["sysname"]] == "SunOS") {
     if (timeout != 1.0) {
@@ -129,7 +132,7 @@ ping_os <- function(destination, continuous, count, timeout) {
     )
   }
 
-  list(cmd = cmd, regex = "^.*time=(.+)[ ]?ms.*$")
+  list(cmd = cmd, env = env, regex = "^.*time=(.+)[ ]?ms.*$")
 }
 
 #' Is the computer online?


### PR DESCRIPTION
On GNU/Linux systems the output of the system `ping` command is often localized, but `pingr::ping` [assumes](../blob/e7cdc4fbf6dc31dd053c7858ee7617ec5a3b6447/R/ping-package.r#L132) that the command output contains the English word "time", which causes `pingr::ping` to fail when using a non-English locale.

This patch passes `LC_ALL=C` environment variable to `ping` on Linux systems, which sets the default C locale and ensures that the output is in English.

The problem might also occur on other Unix-like systems, but I cannot test that.