### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -262,8 +262,8 @@ SEXP r_nsl(SEXP hostname, SEXP server, SEXP class, SEXP type) {
 
 #else
 
+#include <netinet/in.h> // This needs to be before resolv.h for FreeBSD, see #19
 #include <resolv.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <arpa/nameser.h>

--- a/src/rping.c
+++ b/src/rping.c
@@ -40,6 +40,10 @@ void usleep(__int64 usec) {
 #  define WINCLEANUP()
 #endif
 
+#ifdef __FreeBSD__
+#include <netinet/in.h> // This needs to be before resolv.h for FreeBSD, see #19
+#endif
+
 #include <sys/types.h>
 #include <sys/time.h>
 #include <errno.h>


### PR DESCRIPTION
The include directive of `netinet/in.h` must be before `resolv.h` on FreeBSD, otherwise, the following errors will occur:

```
In file included from dns.c:265:
/usr/include/resolv.h:159:14: error: array has incomplete element type 'struct sockaddr_in'
                nsaddr_list[MAXNS];     /*%< address of name server */
                           ^
/usr/include/resolv.h:158:9: note: forward declaration of 'struct sockaddr_in'
        struct sockaddr_in
               ^
/usr/include/resolv.h:173:18: error: field has incomplete type 'struct in_addr'
                struct in_addr  addr;
                                ^
/usr/include/resolv.h:173:10: note: forward declaration of 'struct in_addr'
                struct in_addr  addr;
                       ^
/usr/include/resolv.h:198:21: error: field has incomplete type 'struct sockaddr_in'
        struct sockaddr_in      sin;
                                ^
/usr/include/resolv.h:158:9: note: forward declaration of 'struct sockaddr_in'
        struct sockaddr_in
               ^
3 errors generated.
```

The reason is that the `resolv.h` on FreeBSD is not yet self-contained, see this bug report: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=182466

This fix was committed with the FreeBSD port `net/R-cran-pingr` in https://cgit.freebsd.org/ports/commit/?id=fce80f530301d0079d84bc4b818ba957ad29617b.