### PR TITLE
Fix rping.c on FreeBSD

### DIFF
--- a/src/rping.c
+++ b/src/rping.c
@@ -40,6 +40,10 @@ void usleep(__int64 usec) {
 #  define WINCLEANUP()
 #endif
 
+#ifdef __FreeBSD__
+#include <netinet/in.h>
+#endif
+
 #include <sys/types.h>
 #include <sys/time.h>
 #include <errno.h>


### PR DESCRIPTION
The include directive of `netinet/in.h` must be present before `resolv.h` on FreeBSD, otherwise, the following errors will occur:

```
rping.c:82:27: error: use of undeclared identifier 'IPPROTO_TCP'
  if (type == 0) { type = IPPROTO_TCP; } else { type = IPPROTO_UDP; }
                          ^
rping.c:82:56: error: use of undeclared identifier 'IPPROTO_UDP'
  if (type == 0) { type = IPPROTO_TCP; } else { type = IPPROTO_UDP; }
                                                       ^
rping.c:117:24: error: variable has incomplete type 'struct sockaddr_in'
    struct sockaddr_in c_address;
                       ^
rping.c:117:12: note: forward declaration of 'struct sockaddr_in'
    struct sockaddr_in c_address;
           ^
rping.c:128:17: error: use of undeclared identifier 'IPPROTO_UDP'
                      type == IPPROTO_UDP ? SOCK_DGRAM : SOCK_STREAM,
                              ^
4 errors generated.
```

The reason is that the `resolv.h` on FreeBSD is not yet self-contained, see this bug report: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=182466

This fix was committed with the FreeBSD port `net/R-cran-pingr` in https://cgit.freebsd.org/ports/commit/?id=fce80f530301d0079d84bc4b818ba957ad29617b.