### PR TITLE
update regex to handle sub-millisecond response times

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pingr (development version)
 
+* `ping()` now handles sub-millisecond response times (#24).
+
 # pingr 2.0.3
 
 * `ping_port()` now correctly prints the port if `version = TRUE`.

--- a/R/ping-package.R
+++ b/R/ping-package.R
@@ -72,7 +72,7 @@ ping <- function(destination, continuous = FALSE, verbose = continuous,
 
   if (!continuous) {
     timings <- grep(os$regex, output, value = TRUE, perl = TRUE)
-    times <- sub(os$regex, "\\1", timings, perl = TRUE)
+    times <- sub(os$regex, "\\2", timings, perl = TRUE)
     res <- as.numeric(times)
     length(res) <- count
     res
@@ -132,7 +132,7 @@ ping_os <- function(destination, continuous, count, timeout) {
     )
   }
 
-  list(cmd = cmd, env = env, regex = "^.*time=(.+)[ ]?ms.*$")
+  list(cmd = cmd, env = env, regex = "^.*time(=|<)(.+)[ ]?ms.*$")
 }
 
 #' Is the computer online?


### PR DESCRIPTION
the regular expression used to search through ping output for response times only
matches on an equals sign

this change  modifies:
- the regular expression in ping_os() so that less than or equals will both produce matches
- the capture group in ping() is modified accordingly

response time will be reported as 1ms.

closes #24
