### PR TITLE
✨Draft parsing of SRV records in `r_nsl()`✨ 

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -476,7 +476,7 @@ SEXP r_nsl(SEXP hostname, SEXP server, SEXP class, SEXP type) {
                soa[0], soa[1], soa[2], soa[3], soa[4]);
       break; }
 
-    case ns_t_srv: {
+    case ns_t_srv:
       u_int16_t priority, weight, port;
       char target[NS_MAXDNAME];
 
@@ -493,7 +493,7 @@ SEXP r_nsl(SEXP hostname, SEXP server, SEXP class, SEXP type) {
       }
 
       snprintf(buf, sizeof buf, "%u %u %u %s", priority, weight, port, target);
-      break; }
+      break;
 
     default:
       raw = 1;

--- a/src/dns.c
+++ b/src/dns.c
@@ -241,6 +241,14 @@ SEXP r_nsl(SEXP hostname, SEXP server, SEXP class, SEXP type) {
 	       (unsigned int) ptr->Data.SOA.dwDefaultTtl);
       break;
 
+    case DNS_TYPE_SRV:
+      snprintf(buf, sizeof buf, "%u %u %u %s",
+               ptr->Data.SRV.wPriority,
+               ptr->Data.SRV.wWeight,
+               ptr->Data.SRV.wPort,
+               ptr->Data.SRV.pNameTarget);
+      break;
+
     default:
       raw = 1;
       rawdata = PROTECT(Rf_allocVector(RAWSXP, ptr->wDataLength));
@@ -466,6 +474,25 @@ SEXP r_nsl(SEXP hostname, SEXP server, SEXP class, SEXP type) {
       for (j = 0; j < 5; j++) NS_GET32(soa[j], data);
       snprintf(buf2, bufsize, "%u %u %u %u %u",
                soa[0], soa[1], soa[2], soa[3], soa[4]);
+      break; }
+
+    case ns_t_srv: {
+      u_int16_t priority, weight, port;
+      char target[NS_MAXDNAME];
+
+      NS_GET16(priority, data);
+      NS_GET16(weight, data);
+      NS_GET16(port, data);
+      ret = xxns_name_uncompress(ns_msg_base(msg), ns_msg_end(msg),
+                                 data, target, sizeof target);
+      if (ret < 0) {
+#if (__RES >= 19991006)
+        res_nclose(statep);
+#endif
+        R_THROW_SYSTEM_ERROR("Cannot parse SRV target hostname");
+      }
+
+      snprintf(buf, sizeof buf, "%u %u %u %s", priority, weight, port, target);
       break; }
 
     default:

--- a/src/dns.c
+++ b/src/dns.c
@@ -491,7 +491,6 @@ SEXP r_nsl(SEXP hostname, SEXP server, SEXP class, SEXP type) {
 #endif
         R_THROW_SYSTEM_ERROR("Cannot parse SRV target hostname");
       }
-
       snprintf(buf, sizeof buf, "%u %u %u %s", priority, weight, port, target);
       break;
 

--- a/tests/testthat/_snaps/nsl.md
+++ b/tests/testthat/_snaps/nsl.md
@@ -1,0 +1,9 @@
+# nsl function works with SRV records
+
+    Code
+      result$answer$data
+    Output
+      [[1]]
+      [1] "10 100 80 mxtoolbox.com"
+      
+

--- a/tests/testthat/_snaps/nsl.md
+++ b/tests/testthat/_snaps/nsl.md
@@ -1,9 +1,0 @@
-# nsl function works with SRV records
-
-    Code
-      result$answer$data
-    Output
-      [[1]]
-      [1] "10 100 80 mxtoolbox.com"
-      
-

--- a/tests/testthat/test-nsl.R
+++ b/tests/testthat/test-nsl.R
@@ -1,0 +1,6 @@
+test_that("nsl function works with SRV records", {
+  testthat::skip_on_ci()
+
+  result = nsl("_http._tcp.mxtoolbox.com", type = 33L)
+  expect_snapshot(result$answer$data)
+})

--- a/tests/testthat/test-nsl.R
+++ b/tests/testthat/test-nsl.R
@@ -2,5 +2,5 @@ test_that("nsl function works with SRV records", {
   testthat::skip_on_ci()
 
   result = nsl("_http._tcp.mxtoolbox.com", type = 33L)
-  expect_snapshot(result$answer$data)
+  expect_true("10 100 80 mxtoolbox.com" %in% unlist(result$answer$data))
 })


### PR DESCRIPTION
First pass at implementing parsing of SRV records - returns them as a space separated character string.

✨ **Majority of this code was generated via claude code** ✨  - I've reviewed what is generated and everything looks reasonable to me in terms of implementation, matching existing code, and output.

Tested on MacOS and a Windows vm - results again look reasonable but do differ (windows returns multiple lines). Given this discrepancy I've opted for a very minimalistic test based on the original issue. This likely needs revision but there were not other `nsl()` tests yet to crib from.

